### PR TITLE
fix: use relative base path for Vite build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: './',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- ensure built assets load correctly when served from a subdirectory by using a relative base path in Vite config

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f9cd7e85c8329807086fd0cc9d02b