### PR TITLE
Improve UI layout and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,23 +7,27 @@
     <style>
       html, body, #root { height: 100%; margin: 0; }
       body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji; background:#f5f5f5; color:#222; }
-      .btn { padding:8px 12px; background:#e0e0e0; border:1px solid #ccc; color:#111; border-radius:6px; cursor:pointer; }
-      .btn:hover { background:#d5d5d5; }
+      .btn { padding:8px 12px; background:#fff; border:1px solid #000; color:#000; border-radius:6px; cursor:pointer; }
+      .btn:hover { background:#f0f0f0; }
       .header { position:fixed; top:0; left:0; right:0; background:#fff; border-bottom:1px solid #ddd; display:flex; justify-content:space-between; align-items:center; padding:8px 16px; z-index:40; }
       .workspace { display:flex; height:calc(100% - 52px); margin-top:52px; }
       .canvasWrap { flex:1; display:flex; gap:16px; padding:16px; flex-wrap:wrap; justify-content:center; overflow:auto; }
       .slide { background:#fff; color:#111; border-radius:8px; box-shadow: 0 0 0 1px #ccc inset; position: relative; }
-      .side { background:#f9f9f9; padding:12px; width:220px; overflow:auto; position:relative; }
+      .side { background:#f9f9f9; padding:12px; width:220px; overflow:auto; position:fixed; top:52px; bottom:0; }
+      .side.left { left:0; }
+      .side.right { right:0; }
       .row { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
       .swatch { width:24px; height:24px; border:1px solid #0002; border-radius:4px; }
       .palette { display:flex; gap:6px; flex-wrap:wrap; margin-top:8px; }
       .small { font-size:12px; color:#aaa; }
       .blockToolbar { display:flex; flex-direction:column; gap:8px; }
       .blockToolbar .btn { width:100%; text-transform:capitalize; }
-      .drawerOpener { width:20px; background:#f0f0f0; display:flex; align-items:center; justify-content:center; cursor:pointer; border-right:1px solid #ddd; }
-      .drawerOpener.right { border-right:none; border-left:1px solid #ddd; }
-      .drawerToggle { position:absolute; top:8px; right:8px; width:24px; height:24px; background:#e0e0e0; border:1px solid #ccc; border-radius:4px; display:flex; align-items:center; justify-content:center; cursor:pointer; }
+      .drawerOpener { width:20px; background:#f0f0f0; display:flex; align-items:center; justify-content:center; cursor:pointer; border-right:1px solid #ddd; position:fixed; top:52px; bottom:0; left:0; }
+      .drawerOpener.right { border-right:none; border-left:1px solid #ddd; right:0; left:auto; }
+      .drawerToggle { position:absolute; top:8px; right:8px; width:24px; height:24px; background:#fff; border:1px solid #000; border-radius:4px; display:flex; align-items:center; justify-content:center; cursor:pointer; }
       .handle { position:absolute; right:6px; bottom:6px; background:#fff; color:#333; font-size:12px; padding:2px 6px; border-radius:4px; border:1px solid #ccc; }
+      input[type="checkbox"], input[type="range"] { accent-color:#000; }
+      input, select { border:1px solid #000; }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Refreshed layout with fixed Content and Settings sidebars, white buttons, and new icons
- Brand controls moved to Content toolbar and added slide duplication option
- Settings sidebar now offers adjustable margin, gutter, and column count with slider+input controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689faf0cf3fc8329bf0be60e10c60b86