### PR TITLE
feat: add adjustable brand and generic components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,13 @@ export default function App() {
   const [active, setActive] = React.useState('s1');
   const slideRefs = React.useRef({});
   const logoRef = React.useRef(null);
+  const imageryRef = React.useRef(null);
+  const iconRef = React.useRef(null);
+  const genericImageRef = React.useRef(null);
+  const [voiceTone, setVoiceTone] = React.useState('');
+  const [genericText, setGenericText] = React.useState('');
+  const [genericColorName, setGenericColorName] = React.useState('');
+  const [genericColorValue, setGenericColorValue] = React.useState('#000000');
 
   const dim = format === 'A4' ? DEFAULT_A4 : DEFAULT_169;
     const [snap, setSnap] = React.useState(true);
@@ -116,8 +123,7 @@ export default function App() {
     addBlock(type, { text });
   };
   const addColorsBlock = () => {
-    const text = colorsList.map(c => `${c.name}: ${c.value}`).join('\n');
-    addBlock('colors', { text });
+    addBlock('colors', { colors: colorsList });
   };
   const addTypographyBlock = () => {
     const text = `Heading: ${headingFont}\nBody: ${bodyFont}`;
@@ -132,6 +138,47 @@ export default function App() {
       e.target.value = '';
     };
     reader.readAsDataURL(file);
+  };
+  const onImageryFile = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      addBlock('imagery', { url: reader.result });
+      e.target.value = '';
+    };
+    reader.readAsDataURL(file);
+  };
+  const onIconFile = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      addBlock('iconography', { url: reader.result });
+      e.target.value = '';
+    };
+    reader.readAsDataURL(file);
+  };
+  const onGenericImage = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      addBlock('image', { url: reader.result });
+      e.target.value = '';
+    };
+    reader.readAsDataURL(file);
+  };
+  const addVoiceToneBlock = () => {
+    addTextBlock('voice & tone', voiceTone);
+  };
+  const addGenericTextBlock = () => {
+    addTextBlock('textbox', genericText);
+    setGenericText('');
+  };
+  const addGenericSwatch = () => {
+    addBlock('color-swatch', { label: genericColorName, color: genericColorValue });
+    setGenericColorName('');
   };
   const loadFont = (name) => {
     if (!name) return;
@@ -244,6 +291,40 @@ export default function App() {
                   <input value={bodyFont} onChange={e=>{setBodyFont(e.target.value); loadFont(e.target.value);}} style={{ flex:1 }} />
                 </div>
                 <button className="btn" onClick={addTypographyBlock}>Add Typography Block</button>
+              </section>
+              <section style={{ marginBottom:16 }}>
+                <h3 style={{ margin:0, marginBottom:8 }}>Imagery & Iconography</h3>
+                <div className="row" style={{ marginBottom:8 }}>
+                  <button className="btn" onClick={()=>imageryRef.current?.click()}>Add Imagery</button>
+                  <input type="file" accept="image/*" ref={imageryRef} style={{ display:'none' }} onChange={onImageryFile} />
+                </div>
+                <div className="row" style={{ marginBottom:8 }}>
+                  <button className="btn" onClick={()=>iconRef.current?.click()}>Add Icon</button>
+                  <input type="file" accept="image/*" ref={iconRef} style={{ display:'none' }} onChange={onIconFile} />
+                </div>
+              </section>
+              <section style={{ marginBottom:16 }}>
+                <h3 style={{ margin:0, marginBottom:8 }}>Voice & Tone <StatusDot done={autoChecks['voice & tone']} /></h3>
+                <textarea value={voiceTone} onChange={e=>setVoiceTone(e.target.value)} style={{ width:'100%', marginBottom:8 }} />
+                <button className="btn" onClick={addVoiceToneBlock}>Add</button>
+              </section>
+              <section style={{ marginBottom:16 }}>
+                <h3 style={{ margin:0, marginBottom:8 }}>Generic Components</h3>
+                <div className="row" style={{ marginBottom:8 }}>
+                  <input placeholder="Text" value={genericText} onChange={e=>setGenericText(e.target.value)} style={{ flex:1 }} />
+                  <button className="btn" onClick={addGenericTextBlock}>Add Text</button>
+                </div>
+                <div className="row" style={{ marginBottom:8 }}>
+                  <label className="btn" style={{ flex:1, textAlign:'center' }}>
+                    Add Image
+                    <input type="file" accept="image/*" ref={genericImageRef} style={{ display:'none' }} onChange={onGenericImage} />
+                  </label>
+                </div>
+                <div className="row" style={{ marginBottom:8 }}>
+                  <input placeholder="Label" value={genericColorName} onChange={e=>setGenericColorName(e.target.value)} style={{ flex:1 }} />
+                  <input type="color" value={genericColorValue} onChange={e=>setGenericColorValue(e.target.value)} />
+                  <button className="btn" onClick={addGenericSwatch}>Add Swatch</button>
+                </div>
               </section>
             </aside>
           ) : (

--- a/src/components/ColorPaletteBlock.jsx
+++ b/src/components/ColorPaletteBlock.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ColorSwatch from './ColorSwatch.jsx';
+
+export default function ColorPaletteBlock({ colors = [] }) {
+  return (
+    <div style={{ display: 'flex', gap: 8, width: '100%', height: '100%', padding: 8, boxSizing: 'border-box' }}>
+      {colors.map((c, i) => (
+        <ColorSwatch key={i} color={c.value} label={c.name} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ColorSwatch.jsx
+++ b/src/components/ColorSwatch.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ColorSwatch({ color, label }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', height: '100%', padding: 8, boxSizing: 'border-box' }}>
+      <div style={{ backgroundColor: color || '#ccc', width: '100%', height: '60%', border: '1px solid #999', borderRadius: 4 }} />
+      {label && <span style={{ marginTop: 4, fontSize: 12 }}>{label}</span>}
+    </div>
+  );
+}

--- a/src/components/ImageBlock.jsx
+++ b/src/components/ImageBlock.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function ImageBlock({ url, alt }) {
+  if (!url) return null;
+  return (
+    <img
+      src={url}
+      alt={alt}
+      style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+    />
+  );
+}

--- a/src/components/Slide.jsx
+++ b/src/components/Slide.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import GridOverlay from './GridOverlay.jsx';
 import { IMAGE_BLOCKS } from '../constants.js';
+import TextBox from './TextBox.jsx';
+import ImageBlock from './ImageBlock.jsx';
+import ColorSwatch from './ColorSwatch.jsx';
+import ColorPaletteBlock from './ColorPaletteBlock.jsx';
 
 const snapPos = (v, step, margin) => Math.round((v - margin) / step) * step + margin;
 const snapSize = (v, step, gutter) => {
@@ -87,21 +91,25 @@ function DraggableBlock({ block, onChange, onRemove, grid, snap }) {
   return (
     <div
       ref={ref}
-      style={{ position:'absolute', left:block.x, top:block.y, width:block.w, height:block.h, background:'#fff', boxShadow:'0 0 0 1px #0003, 0 8px 20px #0002', cursor:'grab' }}
+      style={{ position: 'absolute', left: block.x, top: block.y, width: block.w, height: block.h, background: '#fff', boxShadow: '0 0 0 1px #0003, 0 8px 20px #0002', cursor: 'grab' }}
       onMouseDown={onMouseDown}
     >
       {IMAGE_BLOCKS.includes(block.type) ? (
-        block.url && <img src={block.url} alt={block.type} style={{ width:'100%', height:'100%', objectFit:'cover' }} />
+        block.url && <ImageBlock url={block.url} alt={block.type} />
+      ) : block.type === 'color-swatch' ? (
+        <ColorSwatch color={block.color} label={block.label} />
+      ) : block.type === 'colors' ? (
+        <ColorPaletteBlock colors={block.colors || []} />
       ) : (
-        <div
-          contentEditable
-          suppressContentEditableWarning
-          style={{ width:'100%', height:'100%', padding:8, boxSizing:'border-box' }}
-          onBlur={e=>onChange({ text: e.target.innerText })}
-        >{block.text || block.type}</div>
+        <TextBox text={block.text || block.type} onChange={text => onChange({ text })} />
       )}
       <div className="handle" onMouseDown={onResizeDown}>⤡</div>
-      <button onClick={onRemove} style={{ position:'absolute', right:6, top:6, background:'#eee', color:'#333', border:'1px solid #ccc', borderRadius:4, padding:'2px 6px', cursor:'pointer' }}>×</button>
+      <button
+        onClick={onRemove}
+        style={{ position: 'absolute', right: 6, top: 6, background: '#eee', color: '#333', border: '1px solid #ccc', borderRadius: 4, padding: '2px 6px', cursor: 'pointer' }}
+      >
+        ×
+      </button>
     </div>
   );
 }

--- a/src/components/TextBox.jsx
+++ b/src/components/TextBox.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function TextBox({ text, onChange }) {
+  return (
+    <div
+      contentEditable
+      suppressContentEditableWarning
+      style={{ width: '100%', height: '100%', padding: 8, boxSizing: 'border-box' }}
+      onBlur={e => onChange && onChange(e.target.innerText)}
+    >
+      {text}
+    </div>
+  );
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,7 +14,11 @@ export const BLOCK_TYPES = [
   'layout',
   'voice & tone',
   'applications',
-  'accessibility'
+  'accessibility',
+  // Generic components
+  'textbox',
+  'image',
+  'color-swatch'
 ];
 
-export const IMAGE_BLOCKS = ['logo','imagery','iconography'];
+export const IMAGE_BLOCKS = ['logo', 'imagery', 'iconography', 'image'];


### PR DESCRIPTION
## Summary
- support image, color swatch, and textbox blocks
- add sidebar sections for imagery, iconography, voice & tone, and generic components
- render color palettes and swatches using reusable components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb6a8fbec83299f28ab3eec1ae9fd