### PR TITLE
Improve drawer accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,10 @@
       .small { font-size:12px; color:#aaa; }
       .statusDot { display:inline-block; width:8px; height:8px; border-radius:50%; background:#ccc; margin-left:4px; }
       .statusDot.done { background:#000; }
-      .drawerOpener { width:20px; background:#f0f0f0; display:flex; align-items:center; justify-content:center; cursor:pointer; border-right:1px solid #ddd; position:fixed; top:52px; bottom:0; left:0; }
+      .drawerOpener { width:20px; background:#f0f0f0; display:flex; align-items:center; justify-content:center; cursor:pointer; border:none; border-right:1px solid #ddd; position:fixed; top:52px; bottom:0; left:0; padding:0; }
       .drawerOpener.right { border-right:none; border-left:1px solid #ddd; right:0; left:auto; }
-      .drawerToggle { position:absolute; top:8px; right:8px; width:24px; height:24px; background:#fff; border:1px solid #000; border-radius:4px; display:flex; align-items:center; justify-content:center; cursor:pointer; }
+      .drawerToggle { position:absolute; top:8px; right:8px; width:24px; height:24px; background:#fff; border:1px solid #000; border-radius:4px; display:flex; align-items:center; justify-content:center; cursor:pointer; padding:0; }
+      .drawerOpener:focus, .drawerToggle:focus { outline:2px solid #000; }
       .handle { position:absolute; right:6px; bottom:6px; background:#fff; color:#333; font-size:12px; padding:2px 6px; border-radius:4px; border:1px solid #ccc; }
       input[type="checkbox"], input[type="range"] { accent-color:#000; }
       input, select { border:1px solid #000; }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -255,7 +255,14 @@ export default function App() {
         <div className="workspace" style={{ paddingLeft:leftOpen?220:20, paddingRight:rightOpen?220:20, boxSizing:'border-box' }}>
           {leftOpen ? (
             <aside className="side left">
-              <div className="drawerToggle" onClick={()=>setLeftOpen(false)}>◀</div>
+              <button
+                type="button"
+                className="drawerToggle"
+                aria-label="Close content panel"
+                onClick={() => setLeftOpen(false)}
+              >
+                ◀
+              </button>
               <h2 style={{ marginTop:0 }}>Content</h2>
               <div className="row" style={{ marginBottom:12 }}>
                 <select className="btn" value={format} onChange={e=>setFormat(e.target.value)}>
@@ -361,7 +368,14 @@ export default function App() {
               </section>
             </aside>
           ) : (
-            <div className="drawerOpener" onClick={()=>setLeftOpen(true)}>▶</div>
+            <button
+              type="button"
+              className="drawerOpener"
+              aria-label="Open content panel"
+              onClick={() => setLeftOpen(true)}
+            >
+              ▶
+            </button>
           )}
 
           <div className="canvasWrap">
@@ -398,7 +412,14 @@ export default function App() {
 
           {rightOpen ? (
             <aside className="side right">
-              <div className="drawerToggle" onClick={()=>setRightOpen(false)}>▶</div>
+              <button
+                type="button"
+                className="drawerToggle"
+                aria-label="Close settings panel"
+                onClick={() => setRightOpen(false)}
+              >
+                ▶
+              </button>
               <h2 style={{ marginTop:0 }}>Settings</h2>
               <div className="row" style={{ marginBottom:12 }}>
                 <label style={{ width:80 }}>Columns</label>
@@ -487,7 +508,14 @@ export default function App() {
               </section>
             </aside>
           ) : (
-            <div className="drawerOpener right" onClick={()=>setRightOpen(true)}>◀</div>
+            <button
+              type="button"
+              className="drawerOpener right"
+              aria-label="Open settings panel"
+              onClick={() => setRightOpen(true)}
+            >
+              ◀
+            </button>
           )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace drawer open/close divs with semantic buttons and aria labels
- Style drawer buttons to maintain appearance and show focus outlines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fc358a0888329857e7d9b04dca8b8