### PR TITLE
feat: support heading and body fonts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -204,15 +204,17 @@ export default function App() {
     const blk = createBlock(type, grid, extra);
     setSlides(slides.map(s => s.id===active?{...s, blocks:[...(s.blocks||[]), blk]}:s));
   };
+  const headingTypes = React.useMemo(() => new Set(['name', 'tagline']), []);
   const addTextBlock = (type, text) => {
-    addBlock(type, { text });
+    const fontFamily = headingTypes.has(type) ? headingFont : bodyFont;
+    addBlock(type, { text, fontFamily });
   };
   const addColorsBlock = () => {
     addBlock('colors', { colors: colorsList });
   };
   const addTypographyBlock = () => {
     const text = `Heading: ${headingFont}\nBody: ${bodyFont}`;
-    addBlock('typography', { text });
+    addBlock('typography', { text, fontFamily: bodyFont });
   };
   const onLogoFile = (e) => {
     const file = e.target.files[0];
@@ -458,6 +460,8 @@ export default function App() {
                     showSafeMargin={showSafeMargin}
                     backgroundColor={backgroundColor}
                     onChange={b=>setSlideBlocks(s.id,b)}
+                    headingFont={headingFont}
+                    bodyFont={bodyFont}
                   />
                 </div>
                 <div className="row" style={{ justifyContent:'space-between', marginTop:6 }}>

--- a/src/components/Slide.jsx
+++ b/src/components/Slide.jsx
@@ -20,6 +20,8 @@ const snapSize = (v, step, gutter) => {
 let idCounter = 1;
 const newId = () => 'blk_' + idCounter++;
 
+const HEADING_TYPES = new Set(['name', 'tagline']);
+
 export default function Slide({
   blocks,
   onChange,
@@ -29,7 +31,9 @@ export default function Slide({
   roundedCorners,
   softShadow,
   showSafeMargin,
-  backgroundColor
+  backgroundColor,
+  headingFont,
+  bodyFont
 }) {
   const [selectedId, setSelectedId] = React.useState(null);
   const updateBlock = (id, patch) => {
@@ -66,6 +70,7 @@ export default function Slide({
           onSelect={() => setSelectedId(b.id)}
           onChange={p => updateBlock(b.id, p)}
           onRemove={() => removeBlock(b.id)}
+          fontFamily={b.fontFamily || (HEADING_TYPES.has(b.type) ? headingFont : bodyFont)}
         />
       ))}
       <GridOverlay grid={grid} showSafeMargin={showSafeMargin} />
@@ -73,7 +78,7 @@ export default function Slide({
   );
 }
 
-function DraggableBlock({ block, onChange, onRemove, grid, snap, selected, onSelect }) {
+function DraggableBlock({ block, onChange, onRemove, grid, snap, selected, onSelect, fontFamily }) {
   const ref = React.useRef(null);
   const dragging = React.useRef(false);
   const resizing = React.useRef(false);
@@ -215,7 +220,7 @@ function DraggableBlock({ block, onChange, onRemove, grid, snap, selected, onSel
       ) : block.type === 'colors' ? (
         <ColorPaletteBlock colors={block.colors || []} />
       ) : (
-        <TextBox text={block.text || block.type} onChange={text => onChange({ text })} />
+        <TextBox text={block.text || block.type} fontFamily={fontFamily} onChange={text => onChange({ text })} />
       )}
       <div className="handle" onMouseDown={onResizeDown}>⤡</div>
       <button

--- a/src/components/TextBox.jsx
+++ b/src/components/TextBox.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-export default function TextBox({ text, onChange }) {
+export default function TextBox({ text, onChange, fontFamily }) {
   return (
     <div
       contentEditable
       suppressContentEditableWarning
-      style={{ width: '100%', height: '100%', padding: 8, boxSizing: 'border-box' }}
+      style={{ width: '100%', height: '100%', padding: 8, boxSizing: 'border-box', fontFamily }}
       onBlur={e => onChange && onChange(e.target.innerText)}
     >
       {text}


### PR DESCRIPTION
## Summary
- allow TextBox to receive a font family and render with it
- choose heading or body font when adding text blocks and send fonts down to Slide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fc80422c88329a47f941dfeb801d9