### PR TITLE
Rename board padding to slide margins

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
       .header { position:fixed; top:0; left:0; right:0; background:#fff; border-bottom:1px solid #ddd; display:flex; justify-content:space-between; align-items:center; padding:8px 16px; z-index:40; }
       .workspace { display:flex; height:calc(100% - 52px); margin-top:52px; }
       .canvasWrap { flex:1; display:flex; gap:16px; padding:16px; flex-wrap:wrap; justify-content:center; overflow:auto; }
-      .slide { background:#fff; color:#111; border-radius:8px; box-shadow: 0 0 0 1px #ccc inset; position: relative; }
+      .slide { background:#fff; color:#111; border-radius:0; box-shadow: 0 0 0 1px #ccc inset; position: relative; }
       .side { background:#f9f9f9; padding:12px; width:220px; overflow:auto; position:fixed; top:52px; bottom:0; }
       .side.left { left:0; }
       .side.right { right:0; }
@@ -27,6 +27,8 @@
       .handle { position:absolute; right:6px; bottom:6px; background:#fff; color:#333; font-size:12px; padding:2px 6px; border-radius:4px; border:1px solid #ccc; }
       input[type="checkbox"], input[type="range"] { accent-color:#000; }
       input, select { border:1px solid #000; }
+      .exporting .gridOverlay, .exporting .handle, .exporting .slideCanvas button { display:none !important; }
+      .exporting * { outline:none !important; }
     </style>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -64,23 +64,21 @@ export default function App() {
     const { margin, ...rest } = GRID_PRESETS['A4'];
     return rest;
   });
-  const [boardPadding, setBoardPadding] = React.useState(GRID_PRESETS['A4'].margin);
-  const [roundedCorners, setRoundedCorners] = React.useState(false);
-  const [softShadow, setSoftShadow] = React.useState(false);
+  const [slideMargin, setSlideMargin] = React.useState(GRID_PRESETS['A4'].margin);
   const [showSafeMargin, setShowSafeMargin] = React.useState(false);
   const [backgroundColor, setBackgroundColor] = React.useState('#ffffff');
   const [exportFormat, setExportFormat] = React.useState('png');
   const grid = computeGrid(
     format,
-    dim.w - boardPadding * 2,
-    dim.h - boardPadding * 2,
+    dim.w - slideMargin * 2,
+    dim.h - slideMargin * 2,
     { ...gridSettings, margin: 0 }
   );
 
   React.useEffect(() => {
     const { margin, ...rest } = GRID_PRESETS[format];
     setGridSettings(rest);
-    setBoardPadding(margin);
+    setSlideMargin(margin);
   }, [format]);
 
     const addSlide = () => {
@@ -156,7 +154,9 @@ export default function App() {
   const saveImage = React.useCallback(async () => {
     const node = slideRefs.current[active];
     if (!node) return;
+    node.classList.add('exporting');
     const canvas = await html2canvas(node, { backgroundColor, scale: 2 });
+    node.classList.remove('exporting');
     const mime = exportFormat === 'jpeg' ? 'image/jpeg' : 'image/png';
     const link = document.createElement('a');
     link.download = `${brandName.replace(/\s+/g,'_')}.${exportFormat}`;
@@ -169,7 +169,9 @@ export default function App() {
     for (const s of slides) {
       const node = slideRefs.current[s.id];
       if (!node) continue;
+      node.classList.add('exporting');
       const canvas = await html2canvas(node, { backgroundColor, scale: 2 });
+      node.classList.remove('exporting');
       pages.push(canvas.toDataURL('image/png'));
     }
     // PDF size in px units
@@ -454,9 +456,7 @@ export default function App() {
                     blocks={s.blocks || []}
                     grid={grid}
                     snap={snap}
-                    boardPadding={boardPadding}
-                    roundedCorners={roundedCorners}
-                    softShadow={softShadow}
+                    slideMargin={slideMargin}
                     showSafeMargin={showSafeMargin}
                     backgroundColor={backgroundColor}
                     onChange={b=>setSlideBlocks(s.id,b)}
@@ -513,9 +513,9 @@ export default function App() {
                 <input type="number" value={gridSettings.gutter} onChange={e=>setGridSettings({...gridSettings, gutter:parseInt(e.target.value)||0})} style={{ width:60 }} />
               </div>
               <div className="row" style={{ marginBottom:12 }}>
-                <label style={{ width:80 }}>Board padding</label>
-                <input type="range" min="0" max="200" value={boardPadding} onChange={e=>setBoardPadding(parseInt(e.target.value)||0)} />
-                <input type="number" value={boardPadding} onChange={e=>setBoardPadding(parseInt(e.target.value)||0)} style={{ width:60 }} />
+                <label style={{ width:80 }}>Slide margins</label>
+                <input type="range" min="0" max="200" value={slideMargin} onChange={e=>setSlideMargin(parseInt(e.target.value)||0)} />
+                <input type="number" value={slideMargin} onChange={e=>setSlideMargin(parseInt(e.target.value)||0)} style={{ width:60 }} />
               </div>
               <div className="row" style={{ marginBottom:12 }}>
                 <label style={{ width:80 }}>Safe margin</label>
@@ -546,12 +546,7 @@ export default function App() {
               <div className="row" style={{ marginBottom:12 }}>
                 <label><input type="checkbox" checked={snap} onChange={e=>setSnap(e.target.checked)} /> Snap to grid</label>
               </div>
-              <div className="row" style={{ marginBottom:12 }}>
-                <label><input type="checkbox" checked={roundedCorners} onChange={e=>setRoundedCorners(e.target.checked)} /> Rounded corners</label>
-              </div>
-              <div className="row" style={{ marginBottom:12 }}>
-                <label><input type="checkbox" checked={softShadow} onChange={e=>setSoftShadow(e.target.checked)} /> Soft shadow</label>
-              </div>
+              
               <div className="row" style={{ marginBottom:12 }}>
                 <label><input type="checkbox" checked={showSafeMargin} onChange={e=>setShowSafeMargin(e.target.checked)} /> Show safe margin</label>
               </div>

--- a/src/components/GridOverlay.jsx
+++ b/src/components/GridOverlay.jsx
@@ -28,7 +28,7 @@ export default function GridOverlay({ grid, showSafeMargin }) {
     border: '2px dashed #f00',
   };
   return (
-    <div style={style}>
+    <div className="gridOverlay" style={style}>
       <div style={innerStyle}></div>
       {showSafeMargin && safeMargin > 0 && <div style={safeStyle}></div>}
     </div>

--- a/src/components/Slide.jsx
+++ b/src/components/Slide.jsx
@@ -27,9 +27,7 @@ export default function Slide({
   onChange,
   grid,
   snap,
-  boardPadding,
-  roundedCorners,
-  softShadow,
+  slideMargin,
   showSafeMargin,
   backgroundColor,
   headingFont,
@@ -53,11 +51,11 @@ export default function Slide({
         position: 'relative',
         width: '100%',
         height: '100%',
-        padding: boardPadding,
+        padding: slideMargin,
         boxSizing: 'border-box',
         background: backgroundColor,
-        borderRadius: roundedCorners ? 12 : 0,
-        boxShadow: softShadow ? '0 0 0 1px #0003, 0 8px 20px #0002' : '0 0 0 1px #0003'
+        borderRadius: 0,
+        boxShadow: '0 0 0 1px #0003'
       }}
     >
       {blocks.map(b => (


### PR DESCRIPTION
## Summary
- replace board padding with slide margins option
- remove rounded corner and soft shadow settings
- hide grid and interface elements when exporting

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fc98bcf28832999aa0b586c0f2914