### PR TITLE
Ensure slideMargin captured in undo snapshots

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,9 +77,7 @@ export default function App() {
         genericColorValue,
         snap,
         gridSettings,
-        boardPadding,
-        roundedCorners,
-        softShadow,
+        slideMargin,
         showSafeMargin,
         backgroundColor,
       })
@@ -104,9 +102,7 @@ export default function App() {
     setGenericColorValue(s.genericColorValue);
     setSnap(s.snap);
     setGridSettings(s.gridSettings);
-    setBoardPadding(s.boardPadding);
-    setRoundedCorners(s.roundedCorners);
-    setSoftShadow(s.softShadow);
+    setSlideMargin(s.slideMargin);
     setShowSafeMargin(s.showSafeMargin);
     setBackgroundColor(s.backgroundColor);
   };
@@ -154,9 +150,7 @@ export default function App() {
     genericColorValue,
     snap,
     gridSettings,
-    boardPadding,
-    roundedCorners,
-    softShadow,
+    slideMargin,
     showSafeMargin,
     backgroundColor,
   ]);


### PR DESCRIPTION
## Summary
- track slideMargin in snapshot history and restore logic
- remove obsolete boardPadding, roundedCorners, and softShadow references

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd1459df88329af734fb96bc03114