### PR TITLE
Add slide zoom control with scaling support

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       .headerDropdown { position:absolute; z-index:50; }
       .workspace { display:flex; height:calc(100% - 52px); margin-top:52px; }
       .canvasWrap { position:relative; flex:1; display:flex; gap:16px; padding:16px; flex-wrap:wrap; justify-content:center; overflow:auto; z-index:0; }
+      .slideWrapper { width:fit-content; height:fit-content; }
       .slide { background:#fff; color:#111; border-radius:0; box-shadow: 0 0 0 1px #ccc inset; position: relative; z-index:10; }
       .side { background:#f9f9f9; padding:12px; width:220px; overflow:auto; position:fixed; top:52px; bottom:0; z-index:40; }
       .side.left { left:0; }

--- a/src/components/Slide.jsx
+++ b/src/components/Slide.jsx
@@ -23,16 +23,17 @@ const newId = () => 'blk_' + idCounter++;
 const HEADING_TYPES = new Set(['name', 'tagline']);
 
 export default function Slide({
-  blocks,
-  onChange,
-  grid,
-  snap,
-  slideMargin,
-  showSafeMargin,
-  backgroundColor,
-  headingFont,
-  bodyFont
-}) {
+    blocks,
+    onChange,
+    grid,
+    snap,
+    slideMargin,
+    showSafeMargin,
+    backgroundColor,
+    headingFont,
+    bodyFont,
+    zoom = 1
+  }) {
   const [selectedId, setSelectedId] = React.useState(null);
   const updateBlock = (id, patch) => {
     const next = blocks.map(b => (b.id === id ? { ...b, ...patch } : b));
@@ -58,25 +59,26 @@ export default function Slide({
         boxShadow: '0 0 0 1px #0003'
       }}
     >
-      {blocks.map(b => (
-        <DraggableBlock
-          key={b.id}
-          block={b}
-          grid={grid}
-          snap={snap}
-          selected={selectedId === b.id}
-          onSelect={() => setSelectedId(b.id)}
-          onChange={p => updateBlock(b.id, p)}
-          onRemove={() => removeBlock(b.id)}
-          fontFamily={b.fontFamily || (HEADING_TYPES.has(b.type) ? headingFont : bodyFont)}
-        />
-      ))}
+        {blocks.map(b => (
+          <DraggableBlock
+            key={b.id}
+            block={b}
+            grid={grid}
+            snap={snap}
+            selected={selectedId === b.id}
+            onSelect={() => setSelectedId(b.id)}
+            onChange={p => updateBlock(b.id, p)}
+            onRemove={() => removeBlock(b.id)}
+            fontFamily={b.fontFamily || (HEADING_TYPES.has(b.type) ? headingFont : bodyFont)}
+            zoom={zoom}
+          />
+        ))}
       <GridOverlay grid={grid} showSafeMargin={showSafeMargin} />
     </div>
   );
 }
 
-function DraggableBlock({ block, onChange, onRemove, grid, snap, selected, onSelect, fontFamily }) {
+  function DraggableBlock({ block, onChange, onRemove, grid, snap, selected, onSelect, fontFamily, zoom = 1 }) {
   const ref = React.useRef(null);
   const dragging = React.useRef(false);
   const resizing = React.useRef(false);
@@ -90,10 +92,10 @@ function DraggableBlock({ block, onChange, onRemove, grid, snap, selected, onSel
     e.preventDefault();
   };
   const onMouseMove = (e) => {
-    const { margin, safeMargin, width, height } = grid;
-    if (dragging.current) {
-      const dx = e.clientX - start.current.x;
-      const dy = e.clientY - start.current.y;
+      const { margin, safeMargin, width, height } = grid;
+      if (dragging.current) {
+        const dx = (e.clientX - start.current.x) / zoom;
+        const dy = (e.clientY - start.current.y) / zoom;
       const x = Math.min(
         Math.max(start.current.left + dx, margin + safeMargin),
         width - margin - safeMargin - block.w
@@ -103,11 +105,11 @@ function DraggableBlock({ block, onChange, onRemove, grid, snap, selected, onSel
         height - margin - safeMargin - block.h
       );
       onChange({ x, y });
-    } else if (resizing.current) {
-      const dx = e.clientX - start.current.x;
-      const dy = e.clientY - start.current.y;
-      onChange({ w: Math.max(40, start.current.w + dx), h: Math.max(40, start.current.h + dy) });
-    }
+      } else if (resizing.current) {
+        const dx = (e.clientX - start.current.x) / zoom;
+        const dy = (e.clientY - start.current.y) / zoom;
+        onChange({ w: Math.max(40, start.current.w + dx), h: Math.max(40, start.current.h + dy) });
+      }
   };
   const onMouseUp = () => {
     if (dragging.current || resizing.current) {


### PR DESCRIPTION
## Summary
- add zoom state and slider with fit-to-screen helper
- scale slides with transform and adjust drag/resize logic using zoom
- add wrapper styles to handle scaled dimensions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fd6ab12ac8329a169cb5cc7d697e4