### PR TITLE
refactor: move styles to css files

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,34 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Method Mark – Brand PDF Builder</title>
-    <style>
-      html, body, #root { height: 100%; margin: 0; }
-      body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji; background:#f5f5f5; color:#222; }
-      .btn { padding:8px 12px; background:#fff; border:1px solid #000; color:#000; border-radius:6px; cursor:pointer; }
-      .btn:hover { background:#f0f0f0; }
-      .header { position:fixed; top:0; left:0; right:0; background:#fff; border-bottom:1px solid #ddd; display:flex; justify-content:space-between; align-items:center; padding:8px 16px; z-index:60; }
-      .headerDropdown { position:absolute; z-index:50; }
-      .workspace { display:flex; height:calc(100% - 52px); margin-top:52px; }
-      .canvasWrap { position:relative; flex:1; display:flex; gap:16px; padding:16px; flex-wrap:wrap; justify-content:center; overflow:auto; z-index:0; }
-      .slideWrapper { width:fit-content; height:fit-content; }
-      .slide { background:#fff; color:#111; border-radius:0; box-shadow: 0 0 0 1px #ccc inset; position: relative; z-index:10; }
-      .side { background:#f9f9f9; padding:12px; width:220px; overflow:auto; position:fixed; top:52px; bottom:0; z-index:40; }
-      .side.left { left:0; }
-      .side.right { right:0; }
-      .row { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
-      .small { font-size:12px; color:#aaa; }
-      .statusDot { display:inline-block; width:8px; height:8px; border-radius:50%; background:#ccc; margin-left:4px; }
-      .statusDot.done { background:#000; }
-      .drawerOpener { width:20px; background:#f0f0f0; display:flex; align-items:center; justify-content:center; cursor:pointer; border:none; border-right:1px solid #ddd; position:fixed; top:52px; bottom:0; left:0; padding:0; z-index:40; }
-      .drawerOpener.right { border-right:none; border-left:1px solid #ddd; right:0; left:auto; }
-      .drawerToggle { position:absolute; top:8px; right:8px; width:24px; height:24px; background:#fff; border:1px solid #000; border-radius:4px; display:flex; align-items:center; justify-content:center; cursor:pointer; padding:0; z-index:40; }
-      .drawerOpener:focus, .drawerToggle:focus { outline:2px solid #000; }
-      .handle { position:absolute; right:6px; bottom:6px; background:#fff; color:#333; font-size:12px; padding:2px 6px; border-radius:4px; border:1px solid #ccc; }
-      input[type="checkbox"], input[type="range"] { accent-color:#000; }
-      input, select { border:1px solid #000; }
-      .exporting .gridOverlay, .exporting .handle, .exporting .slideCanvas button { display:none !important; }
-      .exporting * { outline:none !important; }
-    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/ColorPaletteBlock.jsx
+++ b/src/components/ColorPaletteBlock.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import ColorSwatch from './ColorSwatch.jsx';
+import styles from './ColorPaletteBlock.module.css';
 
 export default function ColorPaletteBlock({ colors = [] }) {
   return (
-    <div style={{ display: 'flex', gap: 8, width: '100%', height: '100%', padding: 8, boxSizing: 'border-box' }}>
+    <div className={styles.wrapper}>
       {colors.map((c, i) => (
         <ColorSwatch key={i} color={c.value} label={c.name} />
       ))}

--- a/src/components/ColorPaletteBlock.module.css
+++ b/src/components/ColorPaletteBlock.module.css
@@ -1,0 +1,8 @@
+.wrapper {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+  height: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+}

--- a/src/components/ColorSwatch.jsx
+++ b/src/components/ColorSwatch.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import styles from './ColorSwatch.module.css';
 
 export default function ColorSwatch({ color, label }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', height: '100%', padding: 8, boxSizing: 'border-box' }}>
-      <div style={{ backgroundColor: color || '#ccc', width: '100%', height: '60%', border: '1px solid #999', borderRadius: 4 }} />
-      {label && <span style={{ marginTop: 4, fontSize: 12 }}>{label}</span>}
+    <div className={styles.wrapper}>
+      <div className={styles.colorBlock} style={{ backgroundColor: color || '#ccc' }} />
+      {label && <span className={styles.label}>{label}</span>}
     </div>
   );
 }

--- a/src/components/ColorSwatch.module.css
+++ b/src/components/ColorSwatch.module.css
@@ -1,0 +1,21 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.colorBlock {
+  width: 100%;
+  height: 60%;
+  border: 1px solid #999;
+  border-radius: 4px;
+}
+
+.label {
+  margin-top: 4px;
+  font-size: 12px;
+}

--- a/src/components/GridOverlay.jsx
+++ b/src/components/GridOverlay.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styles from './GridOverlay.module.css';
 
 export default function GridOverlay({ grid, showSafeMargin }) {
   const {
@@ -12,12 +13,6 @@ export default function GridOverlay({ grid, showSafeMargin }) {
     width,
     height,
   } = grid;
-  const style = {
-    position: 'absolute',
-    inset: 0,
-    pointerEvents: 'none',
-    zIndex: 20,
-  };
   const bgImages = [
     `repeating-linear-gradient(to right, #ddd, #ddd 1px, transparent 1px, transparent ${stepX}px)`,
     `repeating-linear-gradient(to bottom, #ddd, #ddd 1px, transparent 1px, transparent ${stepY}px)`
@@ -28,29 +23,30 @@ export default function GridOverlay({ grid, showSafeMargin }) {
       `repeating-linear-gradient(to bottom, transparent, transparent ${moduleH}px, rgba(0,0,0,0.05) ${moduleH}px, rgba(0,0,0,0.05) ${stepY}px)`
     );
   }
-  const innerStyle = {
-    position: 'absolute',
-    left: margin,
-    top: margin,
-    width: width - margin * 2,
-    height: height - margin * 2,
-    boxSizing: 'border-box',
-    backgroundImage: bgImages.join(','),
-    border: '1px solid #ccc',
-  };
   const safeOffset = margin + safeMargin;
-  const safeStyle = {
-    position: 'absolute',
-    left: safeOffset,
-    top: safeOffset,
-    width: width - safeOffset * 2,
-    height: height - safeOffset * 2,
-    border: '2px dashed #f00',
-  };
   return (
-    <div className="gridOverlay" style={style}>
-      <div style={innerStyle}></div>
-      {showSafeMargin && safeMargin > 0 && <div style={safeStyle}></div>}
+    <div className={`gridOverlay ${styles.overlay}`}>
+      <div
+        className={styles.inner}
+        style={{
+          left: margin,
+          top: margin,
+          width: width - margin * 2,
+          height: height - margin * 2,
+          backgroundImage: bgImages.join(','),
+        }}
+      ></div>
+      {showSafeMargin && safeMargin > 0 && (
+        <div
+          className={styles.safe}
+          style={{
+            left: safeOffset,
+            top: safeOffset,
+            width: width - safeOffset * 2,
+            height: height - safeOffset * 2,
+          }}
+        ></div>
+      )}
     </div>
   );
 }

--- a/src/components/GridOverlay.module.css
+++ b/src/components/GridOverlay.module.css
@@ -1,0 +1,17 @@
+.overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 20;
+}
+
+.inner {
+  position: absolute;
+  box-sizing: border-box;
+  border: 1px solid #ccc;
+}
+
+.safe {
+  position: absolute;
+  border: 2px dashed #f00;
+}

--- a/src/components/Slide.jsx
+++ b/src/components/Slide.jsx
@@ -5,6 +5,7 @@ import TextBox from './TextBox.jsx';
 import ImageBlock from './ImageBlock.jsx';
 import ColorSwatch from './ColorSwatch.jsx';
 import ColorPaletteBlock from './ColorPaletteBlock.jsx';
+import styles from './Slide.module.css';
 
 const snapPos = (v, step, margin, safeMargin, size, max) => {
   const snapped = Math.round((v - margin) / step) * step + margin;
@@ -45,20 +46,11 @@ export default function Slide({
   };
 
   return (
-    <div
-      className="slideCanvas"
-      onMouseDown={e => { if (e.target === e.currentTarget) setSelectedId(null); }}
-      style={{
-        position: 'relative',
-        width: '100%',
-        height: '100%',
-        padding: slideMargin,
-        boxSizing: 'border-box',
-        background: backgroundColor,
-        borderRadius: 0,
-        boxShadow: '0 0 0 1px #0003'
-      }}
-    >
+      <div
+        className={`slideCanvas ${styles.slideCanvas}`}
+        onMouseDown={e => { if (e.target === e.currentTarget) setSelectedId(null); }}
+        style={{ padding: slideMargin, background: backgroundColor }}
+      >
         {blocks.map(b => (
           <DraggableBlock
             key={b.id}
@@ -195,23 +187,13 @@ export default function Slide({
   });
 
   return (
-    <div
-      ref={ref}
-      tabIndex={0}
-      onKeyDown={onKeyDown}
-      onFocus={onSelect}
-        style={{
-          position: 'absolute',
-          left: block.x,
-          top: block.y,
-          width: block.w,
-          height: block.h,
-          background: '#fff',
-          boxShadow: '0 0 0 1px #0003, 0 8px 20px #0002',
-          zIndex: 30,
-          cursor: 'grab',
-          outline: selected ? '2px solid #2684FF' : 'none'
-        }}
+      <div
+        ref={ref}
+        tabIndex={0}
+        onKeyDown={onKeyDown}
+        onFocus={onSelect}
+        className={`${styles.block} ${selected ? styles.selected : ''}`}
+        style={{ left: block.x, top: block.y, width: block.w, height: block.h }}
         onMouseDown={onMouseDown}
       >
       {IMAGE_BLOCKS.includes(block.type) ? (
@@ -224,13 +206,10 @@ export default function Slide({
         <TextBox text={block.text || block.type} fontFamily={fontFamily} onChange={text => onChange({ text })} />
       )}
       <div className="handle" onMouseDown={onResizeDown}>⤡</div>
-      <button
-        onClick={onRemove}
-        style={{ position: 'absolute', right: 6, top: 6, background: '#eee', color: '#333', border: '1px solid #ccc', borderRadius: 4, padding: '2px 6px', cursor: 'pointer' }}
-      >
-        ×
-      </button>
-    </div>
+        <button onClick={onRemove} className={styles.removeButton}>
+          ×
+        </button>
+      </div>
   );
 }
 

--- a/src/components/Slide.module.css
+++ b/src/components/Slide.module.css
@@ -1,0 +1,32 @@
+.slideCanvas {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  border-radius: 0;
+  box-shadow: 0 0 0 1px #0003;
+}
+
+.block {
+  position: absolute;
+  background: #fff;
+  box-shadow: 0 0 0 1px #0003, 0 8px 20px #0002;
+  z-index: 30;
+  cursor: grab;
+}
+
+.selected {
+  outline: 2px solid #2684FF;
+}
+
+.removeButton {
+  position: absolute;
+  right: 6px;
+  top: 6px;
+  background: #eee;
+  color: #333;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 2px 6px;
+  cursor: pointer;
+}

--- a/src/components/TextBox.jsx
+++ b/src/components/TextBox.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import styles from './TextBox.module.css';
 
 export default function TextBox({ text, onChange, fontFamily }) {
   return (
     <div
       contentEditable
       suppressContentEditableWarning
-      style={{ width: '100%', height: '100%', padding: 8, boxSizing: 'border-box', fontFamily }}
+      className={styles.textBox}
+      style={{ fontFamily }}
       onBlur={e => onChange && onChange(e.target.innerText)}
     >
       {text}

--- a/src/components/TextBox.module.css
+++ b/src/components/TextBox.module.css
@@ -1,0 +1,6 @@
+.textBox {
+  width: 100%;
+  height: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
+import './styles/global.css'
 
 createRoot(document.getElementById('root')).render(<App />)

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,26 @@
+html, body, #root { height: 100%; margin: 0; }
+body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji; background:#f5f5f5; color:#222; }
+.btn { padding:8px 12px; background:#fff; border:1px solid #000; color:#000; border-radius:6px; cursor:pointer; }
+.btn:hover { background:#f0f0f0; }
+.header { position:fixed; top:0; left:0; right:0; background:#fff; border-bottom:1px solid #ddd; display:flex; justify-content:space-between; align-items:center; padding:8px 16px; z-index:60; }
+.headerDropdown { position:absolute; z-index:50; }
+.workspace { display:flex; height:calc(100% - 52px); margin-top:52px; }
+.canvasWrap { position:relative; flex:1; display:flex; gap:16px; padding:16px; flex-wrap:wrap; justify-content:center; overflow:auto; z-index:0; }
+.slideWrapper { width:fit-content; height:fit-content; }
+.slide { background:#fff; color:#111; border-radius:0; box-shadow: 0 0 0 1px #ccc inset; position: relative; z-index:10; }
+.side { background:#f9f9f9; padding:12px; width:220px; overflow:auto; position:fixed; top:52px; bottom:0; z-index:40; }
+.side.left { left:0; }
+.side.right { right:0; }
+.row { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+.small { font-size:12px; color:#aaa; }
+.statusDot { display:inline-block; width:8px; height:8px; border-radius:50%; background:#ccc; margin-left:4px; }
+.statusDot.done { background:#000; }
+.drawerOpener { width:20px; background:#f0f0f0; display:flex; align-items:center; justify-content:center; cursor:pointer; border:none; border-right:1px solid #ddd; position:fixed; top:52px; bottom:0; left:0; padding:0; z-index:40; }
+.drawerOpener.right { border-right:none; border-left:1px solid #ddd; right:0; left:auto; }
+.drawerToggle { position:absolute; top:8px; right:8px; width:24px; height:24px; background:#fff; border:1px solid #000; border-radius:4px; display:flex; align-items:center; justify-content:center; cursor:pointer; padding:0; z-index:40; }
+.drawerOpener:focus, .drawerToggle:focus { outline:2px solid #000; }
+.handle { position:absolute; right:6px; bottom:6px; background:#fff; color:#333; font-size:12px; padding:2px 6px; border-radius:4px; border:1px solid #ccc; }
+input[type="checkbox"], input[type="range"] { accent-color:#000; }
+input, select { border:1px solid #000; }
+.exporting .gridOverlay, .exporting .handle, .exporting .slideCanvas button { display:none !important; }
+.exporting * { outline:none !important; }


### PR DESCRIPTION
## Summary
- move global styles from index.html to src/styles/global.css and import in main entry
- replace inline styles with CSS modules for Slide, TextBox, ColorSwatch, ColorPaletteBlock, and GridOverlay components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fddf1fbc88329a972e494f86fbc17