### PR TITLE
Introduce theming and responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Method Mark – Brand PDF Builder</title>
+    <link rel="stylesheet" href="./src/styles/theme.css" />
   </head>
-  <body>
+  <body style="background:var(--color-bg); color:var(--color-text)">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -434,9 +434,9 @@ export default function App() {
               <Button onClick={()=>alert('Method Mark')}>About</Button>
             </div>
           </header>
-        <div className="workspace" style={{ paddingLeft:leftOpen?220:20, paddingRight:rightOpen?220:20, boxSizing:'border-box' }}>
+        <div className={`workspace responsive${leftOpen ? ' left-open' : ''}${rightOpen ? ' right-open' : ''}`}>
           {leftOpen ? (
-            <aside className="side left">
+            <aside className="side left responsive">
               <button
                 type="button"
                 className="drawerToggle"
@@ -612,7 +612,7 @@ export default function App() {
           </div>
 
           {rightOpen ? (
-            <aside className="side right">
+            <aside className="side right responsive">
               <button
                 type="button"
                 className="drawerToggle"

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
+import './styles/theme.css'
 import './styles/global.css'
 
 createRoot(document.getElementById('root')).render(<App />)

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,14 +1,16 @@
 html, body, #root { height: 100%; margin: 0; }
-body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji; background:#f5f5f5; color:#222; }
+body { font-family: var(--font-sans); background: var(--color-bg); color: var(--color-text); }
 .btn { padding:8px 12px; background:#fff; border:1px solid #000; color:#000; border-radius:6px; cursor:pointer; }
 .btn:hover { background:#f0f0f0; }
 .header { position:fixed; top:0; left:0; right:0; background:#fff; border-bottom:1px solid #ddd; display:flex; justify-content:space-between; align-items:center; padding:8px 16px; z-index:60; }
 .headerDropdown { position:absolute; z-index:50; }
-.workspace { display:flex; height:calc(100% - 52px); margin-top:52px; }
+.workspace { display:flex; height:calc(100% - 52px); margin-top:52px; box-sizing:border-box; padding-left:var(--spacing-xl); padding-right:var(--spacing-xl); }
+.workspace.left-open { padding-left:var(--side-width); }
+.workspace.right-open { padding-right:var(--side-width); }
 .canvasWrap { position:relative; flex:1; display:flex; gap:16px; padding:16px; flex-wrap:wrap; justify-content:center; overflow:auto; z-index:0; }
 .slideWrapper { width:fit-content; height:fit-content; }
 .slide { background:#fff; color:#111; border-radius:0; box-shadow: 0 0 0 1px #ccc inset; position: relative; z-index:10; }
-.side { background:#f9f9f9; padding:12px; width:220px; overflow:auto; position:fixed; top:52px; bottom:0; z-index:40; }
+.side { background:var(--color-panel-bg); padding:var(--spacing-md); width:var(--side-width); overflow:auto; position:fixed; top:52px; bottom:0; z-index:40; }
 .side.left { left:0; }
 .side.right { right:0; }
 .row { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
@@ -29,3 +31,10 @@ input[type="checkbox"], input[type="range"] { accent-color:#000; }
 input, select { border:1px solid #000; }
 .exporting .gridOverlay, .exporting .handle, .exporting .slideCanvas button { display:none !important; }
 .exporting * { outline:none !important; }
+
+@media (max-width: 768px) {
+  .workspace.responsive { flex-direction: column; padding-left: var(--spacing-md); padding-right: var(--spacing-md); }
+  .workspace.responsive.left-open { padding-left: var(--spacing-md); }
+  .workspace.responsive.right-open { padding-right: var(--spacing-md); }
+  .side.responsive { position: static; width: 100%; height: auto; }
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,11 @@
+:root {
+  --color-bg: #f5f5f5;
+  --color-text: #222;
+  --color-panel-bg: #f9f9f9;
+  --spacing-sm: 8px;
+  --spacing-md: 12px;
+  --spacing-lg: 16px;
+  --spacing-xl: 20px;
+  --side-width: 220px;
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+}


### PR DESCRIPTION
## Summary
- add central theme.css with color, spacing, and font variables
- refactor layout to use CSS variables and responsive classes
- collapse side panels on narrow viewports via media queries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe1700c9c8329a0ccfc3d0a7553eb