### PR TITLE
Add accessible styles for slide blocks

### DIFF
--- a/src/components/Slide.jsx
+++ b/src/components/Slide.jsx
@@ -206,8 +206,20 @@ export default function Slide({
       ) : (
         <TextBox text={block.text || block.type} fontFamily={fontFamily} onChange={text => onChange({ text })} />
       )}
-      <div className="handle" onMouseDown={onResizeDown}>⤡</div>
-        <Button onClick={onRemove} className={styles.removeButton} variant="secondary">
+      <button
+        type="button"
+        className="handle"
+        aria-label="Resize block"
+        onMouseDown={onResizeDown}
+      >
+        ⤡
+      </button>
+        <Button
+          onClick={onRemove}
+          className={styles.removeButton}
+          variant="secondary"
+          aria-label="Remove block"
+        >
           ×
         </Button>
       </div>

--- a/src/components/Slide.module.css
+++ b/src/components/Slide.module.css
@@ -15,6 +15,18 @@
   cursor: grab;
 }
 
+.block:hover {
+  box-shadow: 0 0 0 1px #0006, 0 8px 20px #0003;
+}
+
+.block:focus {
+  outline: 2px solid #2684FF;
+}
+
+.block:active {
+  cursor: grabbing;
+}
+
 .selected {
   outline: 2px solid #2684FF;
 }
@@ -29,4 +41,16 @@
   border-radius: 4px;
   padding: 2px 6px;
   cursor: pointer;
+}
+
+.removeButton:hover {
+  background: #ddd;
+}
+
+.removeButton:focus {
+  outline: 2px solid #2684FF;
+}
+
+.removeButton:active {
+  background: #ccc;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -26,7 +26,10 @@ body { font-family: var(--font-sans); background: var(--color-bg); color: var(--
 .drawerOpener.right { border-right:none; border-left:1px solid #ddd; right:0; left:auto; }
 .drawerToggle { position:absolute; top:8px; right:8px; width:24px; height:24px; background:#fff; border:1px solid #000; border-radius:4px; display:flex; align-items:center; justify-content:center; cursor:pointer; padding:0; z-index:40; }
 .drawerOpener:focus, .drawerToggle:focus { outline:2px solid #000; }
-.handle { position:absolute; right:6px; bottom:6px; background:#fff; color:#333; font-size:12px; padding:2px 6px; border-radius:4px; border:1px solid #ccc; }
+.handle { position:absolute; right:6px; bottom:6px; background:#fff; color:#333; font-size:12px; padding:2px 6px; border-radius:4px; border:1px solid #ccc; cursor:pointer; }
+.handle:hover { background:#f0f0f0; }
+.handle:focus { outline:2px solid #000; }
+.handle:active { background:#e0e0e0; }
 input[type="checkbox"], input[type="range"] { accent-color:#000; }
 input, select { border:1px solid #000; }
 .exporting .gridOverlay, .exporting .handle, .exporting .slideCanvas button { display:none !important; }


### PR DESCRIPTION
## Summary
- add hover, focus, and active styles for draggable blocks and remove buttons
- add aria labels and focus outlines for resize handles and remove buttons
- improve handle styles for better keyboard navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe310a5348329af7afffe61d19555