### PR TITLE
Add about dropdown to header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { BLOCK_TYPES } from './constants.js'
 import html2canvas from 'html2canvas'
 import jsPDF from 'jspdf'
 import { GRID_PRESETS, computeGrid } from './utils/grid.js'
+import pkg from '../package.json' assert { type: 'json' };
 
 function StatusDot({ done }) {
   return <span className={`statusDot${done ? ' done' : ''}`} />;
@@ -55,6 +56,7 @@ export default function App() {
   const [backgroundColor, setBackgroundColor] = React.useState('#ffffff');
   const [exportFormat, setExportFormat] = React.useState('png');
   const [zoom, setZoom] = React.useState(1);
+  const [showAbout, setShowAbout] = React.useState(false);
   // History stack for undo/redo
   const history = React.useRef([]);
   const future = React.useRef([]);
@@ -431,7 +433,17 @@ export default function App() {
               <Button onClick={undo} disabled={history.current.length <= 1}>Undo</Button>
               <Button onClick={redo} disabled={future.current.length === 0}>Redo</Button>
               <Button onClick={addSlide}>+ Add Slide</Button>
-              <Button onClick={()=>alert('Method Mark')}>About</Button>
+              <div style={{ position: 'relative' }}>
+                <Button onClick={() => setShowAbout(!showAbout)}>?</Button>
+                {showAbout && (
+                  <div className="headerDropdown aboutDropdown">
+                    <p><strong>App Name:</strong> Method Mark</p>
+                    <p><strong>Description:</strong> A lightweight React app to assemble brand boards and export a multi-page PDF in A4 or 16×9.</p>
+                    <p><strong>Created by:</strong> <a href="https://methodlab.ca" target="_blank" rel="noopener noreferrer">Method Lab</a></p>
+                    <p><strong>Version:</strong> {pkg.version}</p>
+                  </div>
+                )}
+              </div>
             </div>
           </header>
         <div className={`workspace responsive${leftOpen ? ' left-open' : ''}${rightOpen ? ' right-open' : ''}`}>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,9 @@ html, body, #root { height: 100%; margin: 0; }
 body { font-family: var(--font-sans); background: var(--color-bg); color: var(--color-text); }
 .header { position:fixed; top:0; left:0; right:0; background:#fff; border-bottom:1px solid #ddd; display:flex; justify-content:space-between; align-items:center; padding:8px 16px; z-index:60; }
 .headerDropdown { position:absolute; z-index:50; }
+.aboutDropdown { top:100%; right:0; background:#fff; border:1px solid #ddd; padding:8px 12px; width:260px; font-size:14px; }
+.aboutDropdown p { margin:0 0 4px; }
+.aboutDropdown p:last-child { margin-bottom:0; }
 .workspace { display:flex; height:calc(100% - 52px); margin-top:52px; box-sizing:border-box; padding-left:var(--spacing-xl); padding-right:var(--spacing-xl); }
 .workspace.left-open { padding-left:var(--side-width); }
 .workspace.right-open { padding-right:var(--side-width); }


### PR DESCRIPTION
## Summary
- replace "About" button with "?" icon that toggles an about dropdown
- show app name, description, creator link, and version fetched from package.json
- style dropdown for proper positioning under header

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f0ae532c8329b9283e6f4423e3de